### PR TITLE
Modified io_check script to output variable value and change ratio

### DIFF
--- a/R_scripts/io_check.r
+++ b/R_scripts/io_check.r
@@ -183,7 +183,7 @@ write(colnames( cow.calf.ori.out)[29:31],fileCom,append=TRUE)
 a<-data.matrix(cow.calf.ori.out)[,29:31]
 b<-data.matrix(cow.calf.mod.out)[,29:31]
 test<-which(a != b, arr.ind=TRUE)
-
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -203,6 +203,9 @@ write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumn
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom,row.names=FALSE, col.names=FALSE,append=TRUE)
 }
 }
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
+}
 
 
 # onsite-pet
@@ -212,6 +215,7 @@ write(colnames(onsite.pets.ori.out)[17:18],fileCom,append=TRUE)
 a<-data.matrix(onsite.pets.ori.out)[,17:18]
 b<-data.matrix(onsite.pets.mod.out)[,17:18]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -232,6 +236,9 @@ write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumn
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
 }
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
+}
 
 # Beaver
 write("", fileCom, append=TRUE)
@@ -240,6 +247,7 @@ write(colnames(beaver.ori.out)[5:6],fileCom,append=TRUE)
 a<-data.matrix(beaver.ori.out)[,5:6]
 b<-data.matrix(beaver.mod.out)[,5:6]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -259,6 +267,9 @@ write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumn
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
 }
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
+}
 
 
 # Coyote
@@ -268,6 +279,7 @@ write(colnames(coyote.ori.out)[cbind(8,12,13,14)],fileCom,append=TRUE)
 a<-data.matrix(coyote.ori.out)[,cbind(8,12,13,14)]
 b<-data.matrix(coyote.mod.out)[,cbind(8,12,13,14)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -286,6 +298,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Deer
@@ -295,6 +310,7 @@ write(colnames(deer.ori.out)[cbind(7,10,11)],fileCom,append=TRUE)
 a<-data.matrix(deer.ori.out)[,cbind(7,10,11)]
 b<-data.matrix(deer.mod.out)[,cbind(7,10,11)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -313,6 +329,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Duck
@@ -322,6 +341,7 @@ write(colnames(duck.ori.out)[8:11],fileCom,append=TRUE)
 a<-data.matrix(duck.ori.out)[,8:11]
 b<-data.matrix(duck.mod.out)[,8:11]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -340,6 +360,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Elk
@@ -349,6 +372,7 @@ write(colnames(elk.ori.out)[cbind(19,32,33,34)],fileCom,append=TRUE)
 a<-data.matrix(elk.ori.out)[,cbind(19,32,33,34)]
 b<-data.matrix(elk.mod.out)[,cbind(19,32,33,34)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -367,6 +391,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Geese
@@ -376,6 +403,7 @@ write(colnames(geese.ori.out)[8:11],fileCom,append=TRUE)
 a<-data.matrix(geese.ori.out)[,8:11]
 b<-data.matrix(geese.mod.out)[,8:11]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -394,6 +422,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Gulls
@@ -403,6 +434,7 @@ write(colnames(gulls.ori.out)[cbind(8,12,13,14)],fileCom,append=TRUE)
 a<-data.matrix(gulls.ori.out)[,cbind(8,12,13,14)]
 b<-data.matrix(gulls.mod.out)[,cbind(8,12,13,14)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -421,6 +453,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 # Herons_Egrets
@@ -430,6 +465,7 @@ write(colnames(heregr.ori.out)[cbind(8,12,13,14)],fileCom,append=TRUE)
 a<-data.matrix(heregr.ori.out)[,cbind(8,12,13,14)]
 b<-data.matrix(heregr.mod.out)[,cbind(8,12,13,14)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -449,6 +485,9 @@ write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumn
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
 }
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
+}
 
 # Otter
 write("", fileCom, append=TRUE)
@@ -457,6 +496,7 @@ write(colnames(otter.ori.out)[cbind(11,16,17)],fileCom,append=TRUE)
 a<-data.matrix(otter.ori.out)[,cbind(11,16,17)]
 b<-data.matrix(otter.mod.out)[,cbind(11,16,17)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -476,6 +516,9 @@ write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumn
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
 }
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
+}
 
 # Raccoon
 write("", fileCom, append=TRUE)
@@ -484,6 +527,7 @@ write(colnames(racoon.ori.out)[cbind(8,12,13,14)],fileCom,append=TRUE)
 a<-data.matrix(racoon.ori.out)[,cbind(8,12,13,14)]
 b<-data.matrix(racoon.mod.out)[,cbind(8,12,13,14)]
 test<-which(a != b, arr.ind=TRUE)
+if (length(test)>0){
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
@@ -502,6 +546,9 @@ write(names(a)[col][i],fileCom,append=TRUE)
 write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
 write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
 }
+}
+}else{
+write("No Different Key Variables", fileCom, append=TRUE)
 }
 
 close(fileCom)

--- a/R_scripts/io_check.r
+++ b/R_scripts/io_check.r
@@ -3,6 +3,8 @@
 # Last Updated: 2015/11/1
 # This script runs original sub-models and modified ones, and then compares the outputs of each sub-model pair, prints out the different key variables.
 
+
+
 io_check<- function(ori.model.wrkdir,mod.model.wrkdir,output.compare.wrkdir=ori.model.wrkdir){
 # Load Original SubModel
 ## Get the path
@@ -181,13 +183,27 @@ write(colnames( cow.calf.ori.out)[29:31],fileCom,append=TRUE)
 a<-data.matrix(cow.calf.ori.out)[,29:31]
 b<-data.matrix(cow.calf.mod.out)[,29:31]
 test<-which(a != b, arr.ind=TRUE)
+
 if (!is.null(dim(test))){
 col<-unique(test[,2])
+write("Different Key Variables:", fileCom, append=TRUE)
+
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
-}
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom,row.names=FALSE, col.names=FALSE,append=TRUE)
+}
+}
+
 
 # onsite-pet
 write("", fileCom, append=TRUE)
@@ -199,11 +215,22 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
+
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Beaver
@@ -217,10 +244,20 @@ if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
 write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 
@@ -234,11 +271,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Deer
@@ -251,11 +298,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Duck
@@ -268,11 +325,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Elk
@@ -285,11 +352,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Geese
@@ -302,11 +379,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Gulls
@@ -319,11 +406,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Herons_Egrets
@@ -336,11 +433,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Otter
@@ -353,11 +460,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col][i],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 # Raccoon
@@ -370,11 +487,21 @@ test<-which(a != b, arr.ind=TRUE)
 if (!is.null(dim(test))){
 col<-unique(test[,2])
 write("Different Key Variables:", fileCom, append=TRUE)
-write(colnames(a)[col],fileCom,append=TRUE)
+#write(colnames(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(colnames(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom, ncolumns=3,append=TRUE)
+write.table(cbind(a[,col[i]],b[,col[i]],a[,col[i]]/b[,col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }else{
 col<-test
 write("Different Key Variables:", fileCom, append=TRUE)
-write(names(a)[col],fileCom,append=TRUE)
+#write(names(a)[col],fileCom,append=TRUE)
+for (i in 1:length(col)){
+write(names(a)[col][i],fileCom,append=TRUE)
+write(cbind("Original_Output","Modified_Output","Change_Ratio"), fileCom,ncolumns=3, append=TRUE)
+write.table(cbind(a[col[i]],b[col[i]],a[col[i]]/b[col[i]]),fileCom, row.names=FALSE, col.names=FALSE, append=TRUE)
+}
 }
 
 close(fileCom)

--- a/R_scripts/output_compare.txt
+++ b/R_scripts/output_compare.txt
@@ -49,35 +49,7 @@ Original_Output Modified_Output Change_Ratio
 Onsite Pets Submodel Key Variables:
 bac.onsite.NearStrmStrctFailure.to.stream.load
 Accum.RAOCUT
-Different Key Variables:
-NA
-Original_Output Modified_Output Change_Ratio
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-NA NA NA
-
-Original_Output Modified_Output Change_Ratio
-
-
-
-
-
-
-
-
-
-
-
-
+No Different Key Variables
 
 Wildlife-Beaver Submodel Key Variables:
 bac.total.in.stream

--- a/R_scripts/output_compare.txt
+++ b/R_scripts/output_compare.txt
@@ -4,13 +4,79 @@ Accum.Pasture
 Accum.Forest
 Different Key Variables:
 Bacteria.Instream
+Original_Output Modified_Output Change_Ratio
+71387156.25 2141614687500 3.33333333333333e-05
+71387156.25 2141614687500 3.33333333333333e-05
+214161468.75 6424844062500 3.33333333333333e-05
+214161468.75 6424844062500 3.33333333333333e-05
+214161468.75 6424844062500 3.33333333333333e-05
+285548625 8566458750000 3.33333333333333e-05
+214198924.051026 6425967721530.79 3.33333333333333e-05
+214198924.051026 6425967721530.79 3.33333333333333e-05
+214198924.051026 6425967721530.79 3.33333333333333e-05
+71387156.25 2141614687500 3.33333333333333e-05
+71387156.25 2141614687500 3.33333333333333e-05
+71387156.25 2141614687500 3.33333333333333e-05
 Accum.Pasture
+Original_Output Modified_Output Change_Ratio
+60277500 1.808325e+12 3.33333333333333e-05
+60277500 1.808325e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+241110000 7.2333e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+180832500 5.424975e+12 3.33333333333333e-05
+60277500 1.808325e+12 3.33333333333333e-05
+60277500 1.808325e+12 3.33333333333333e-05
+60277500 1.808325e+12 3.33333333333333e-05
 Accum.Forest
+Original_Output Modified_Output Change_Ratio
+0 0 NA
+0 0 NA
+0 0 NA
+0 0 NA
+0 0 NA
+0 0 NA
+6533890.55989949 98013559484.5718 6.66631290023498e-05
+6533890.55989949 98013559484.5718 6.66631290023498e-05
+6533890.55989949 98013559484.5718 6.66631290023498e-05
+0 0 NA
+0 0 NA
+0 0 NA
 
 Onsite Pets Submodel Key Variables:
 bac.onsite.NearStrmStrctFailure.to.stream.load
 Accum.RAOCUT
 Different Key Variables:
+NA
+Original_Output Modified_Output Change_Ratio
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+NA NA NA
+
+Original_Output Modified_Output Change_Ratio
+
+
+
+
+
+
+
+
+
+
+
 
 
 Wildlife-Beaver Submodel Key Variables:
@@ -18,6 +84,8 @@ bac.total.in.stream
 Accum.Forest
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+393300 16387.5 24
 
 Wildlife-Coyote Submodel Key Variables:
 bac.total.in.stream
@@ -26,6 +94,8 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+900001150 37500047.9166667 24
 
 Wildlife-Deer Submodel Key Variables:
 bac.total.in.stream
@@ -33,8 +103,14 @@ Accum.Pasture
 Accum.Forest
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+367465720 15311071.6666667 24
 Accum.Pasture
+Original_Output Modified_Output Change_Ratio
+410561 8742246 0.0469628743002656
 Accum.Forest
+Original_Output Modified_Output Change_Ratio
+8177546 8590131 0.95196988264789
 
 Wildlife-Duck Submodel Key Variables:
 bac.total.in.stream
@@ -43,6 +119,19 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+1600000060 66666669.1666667 24
+0 0 NA
+0 0 NA
+0 0 NA
+1600000060 66666669.1666667 24
+1600000060 66666669.1666667 24
+1600000060 66666669.1666667 24
+0 0 NA
+0 0 NA
+0 0 NA
+1600000060 66666669.1666667 24
+1600000060 66666669.1666667 24
 
 Wildlife-Elk Submodel Key Variables:
 bac.total.in.stream
@@ -51,6 +140,19 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+0 0 NA
+0 0 NA
+0 0 NA
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+2.66e+09 110833333.333333 24
+0 0 NA
+0 0 NA
 
 Wildlife-Geese Submodel Key Variables:
 bac.total.in.stream
@@ -59,6 +161,19 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+800000030 33333334.5833333 24
+0 0 NA
+0 0 NA
+0 0 NA
+800000030 33333334.5833333 24
+800000030 33333334.5833333 24
+800000030 33333334.5833333 24
+0 0 NA
+0 0 NA
+0 0 NA
+800000030 33333334.5833333 24
+800000030 33333334.5833333 24
 
 Wildlife-Gulls Submodel Key Variables:
 bac.total.in.stream
@@ -67,6 +182,8 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+129060037800 5377501575 24
 
 Wildlife-Herons_Egrets Submodel Key Variables:
 bac.total.in.stream
@@ -75,6 +192,8 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+1.46268e+11 6094500000 24
 
 Wildlife-Otter Submodel Key Variables:
 bac.total.in.stream
@@ -82,6 +201,8 @@ Accum.Pasture
 Accum.Forest
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+58995000 2458125 24
 
 Wildlife-Raccoon Submodel Key Variables:
 bac.total.in.stream
@@ -90,3 +211,5 @@ Accum.Forest
 Accum.RAOCUT
 Different Key Variables:
 bac.total.in.stream
+Original_Output Modified_Output Change_Ratio
+47500000 1979166.66666667 24


### PR DESCRIPTION
The io_check.r script was modified. If the variables were found different in
original and modified models.  It will print out the variable values of
both models as well as the change ratios (original values/ modified
values). "output_compare.txt" shows the sample format of output.
